### PR TITLE
Add bulk upload batch size control

### DIFF
--- a/js/admin/batch-size-controller.js
+++ b/js/admin/batch-size-controller.js
@@ -1,0 +1,27 @@
+document.addEventListener("DOMContentLoaded", function() { 
+    const bulkUploadField = document.querySelector("#useBulkUpload");
+    const batchSizeWrapper = document.querySelector("#batchSize__wrapper");
+    const batchSizeField = document.querySelector("#batchSize");
+
+    // Handle toggling display of our batch size field
+    if( bulkUploadField && batchSizeWrapper ) {
+        bulkUploadField.addEventListener("input", function() {
+            batchSizeWrapper.classList.toggle("hidden");
+        });
+    }
+
+    // Some simple validation
+    if( batchSizeField ) {
+        batchSizeField.addEventListener("input", function(event) {
+            let batchSize = parseInt(batchSizeField.value);
+            let minBatchSize = parseInt(batchSizeField.getAttribute("min"));
+            let maxBatchSize = parseInt(batchSizeField.getAttribute("max"));
+            if( batchSize < minBatchSize ) {
+                batchSize = minBatchSize;
+            } else if( batchSize > maxBatchSize ) {
+                batchSize = maxBatchSize;
+            }
+            batchSizeField.value = batchSize;
+        })
+    }
+});

--- a/js/admin/batch-size-controller.js
+++ b/js/admin/batch-size-controller.js
@@ -22,6 +22,6 @@ document.addEventListener("DOMContentLoaded", function () {
                 batchSize = maxBatchSize;
             }
             batchSizeField.value = batchSize;
-        })
+        });
     }
 });

--- a/js/admin/batch-size-controller.js
+++ b/js/admin/batch-size-controller.js
@@ -1,24 +1,24 @@
-document.addEventListener("DOMContentLoaded", function() { 
+document.addEventListener("DOMContentLoaded", function () {
     const bulkUploadField = document.querySelector("#useBulkUpload");
     const batchSizeWrapper = document.querySelector("#batchSize__wrapper");
     const batchSizeField = document.querySelector("#batchSize");
 
     // Handle toggling display of our batch size field
-    if( bulkUploadField && batchSizeWrapper ) {
-        bulkUploadField.addEventListener("input", function() {
+    if (bulkUploadField && batchSizeWrapper) {
+        bulkUploadField.addEventListener("input", function () {
             batchSizeWrapper.classList.toggle("hidden");
         });
     }
 
     // Some simple validation
-    if( batchSizeField ) {
-        batchSizeField.addEventListener("input", function(event) {
+    if (batchSizeField) {
+        batchSizeField.addEventListener("input", function (event) {
             let batchSize = parseInt(batchSizeField.value);
             let minBatchSize = parseInt(batchSizeField.getAttribute("min"));
             let maxBatchSize = parseInt(batchSizeField.getAttribute("max"));
-            if( batchSize < minBatchSize ) {
+            if (batchSize < minBatchSize) {
                 batchSize = minBatchSize;
-            } else if( batchSize > maxBatchSize ) {
+            } else if (batchSize > maxBatchSize) {
                 batchSize = maxBatchSize;
             }
             batchSizeField.value = batchSize;

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -135,7 +135,7 @@ class Controller
                 'ie 13e736c51a7a73dabc0b83f75d3bedce'
             )
         );
-        
+
         $wpdb->query(
             $wpdb->prepare(
                 "INSERT IGNORE INTO {$wpdb->prefix}wp2static_addon_cloudflare_workers_options " .
@@ -352,10 +352,10 @@ class Controller
         );
 
         $batchSize = sanitize_text_field($_POST['batchSize']);
-        if( !isset($batchSize) || empty($batchSize) ) {
-            $batchSize = (string) Deployer::BATCH_SIZE_DEFAULT;
+        if (!$batchSize) {
+            $batchSize = (string)Deployer::BATCH_SIZE_DEFAULT;
         }
-        $batchSize = preg_replace('/\D/', "", $batchSize);
+        $batchSize = preg_replace('/\D/', '', $batchSize);
         $wpdb->update(
             $tableName,
             [ 'value' => $batchSize ],
@@ -401,14 +401,15 @@ class Controller
         );
     }
 
-    public static function wp2staticAdminScripts() : void {
+    public static function wp2staticAdminScripts(): void
+    {
         wp_register_script(
             'wp2static_addon_cloudflare_admin_scripts',
-            plugins_url( '../js/admin/batch-size-controller.js', __FILE__ ),
+            plugins_url('../js/admin/batch-size-controller.js', __FILE__),
             [],
             Config::get('version'),
             false
         );
-        wp_enqueue_script( 'wp2static_addon_cloudflare_admin_scripts' );
+        wp_enqueue_script('wp2static_addon_cloudflare_admin_scripts');
     }
 }

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -49,6 +49,12 @@ class Controller
             1
         );
 
+        add_action(
+            'admin_enqueue_scripts',
+            [ $this, 'wp2staticAdminScripts' ],
+            0
+        );
+
         do_action(
             'wp2static_register_addon',
             'wp2static-addon-cloudflare-workers',
@@ -127,6 +133,17 @@ class Controller
                 '',
                 'Account ID',
                 'ie 13e736c51a7a73dabc0b83f75d3bedce'
+            )
+        );
+        
+        $wpdb->query(
+            $wpdb->prepare(
+                "INSERT IGNORE INTO {$wpdb->prefix}wp2static_addon_cloudflare_workers_options " .
+                    '(name, value, label, description) VALUES (%s, %s, %s, %s);',
+                'batchSize',
+                Deployer::BATCH_SIZE_DEFAULT,
+                'Batch Size',
+                'Number of files to include in each batch'
             )
         );
     }
@@ -334,6 +351,17 @@ class Controller
             [ 'name' => 'accountID' ]
         );
 
+        $batchSize = sanitize_text_field($_POST['batchSize']);
+        if( !isset($batchSize) || empty($batchSize) ) {
+            $batchSize = (string) Deployer::BATCH_SIZE_DEFAULT;
+        }
+        $batchSize = preg_replace('/\D/', "", $batchSize);
+        $wpdb->update(
+            $tableName,
+            [ 'value' => $batchSize ],
+            [ 'name' => 'batchSize' ]
+        );
+
         wp_safe_redirect(admin_url('admin.php?page=wp2static-addon-cloudflare-workers'));
         exit;
     }
@@ -371,5 +399,16 @@ class Controller
             'wp2static-addon-cloudflare-workers',
             [ $this, 'renderCloudflareWorkersPage' ]
         );
+    }
+
+    public static function wp2staticAdminScripts() : void {
+        wp_register_script(
+            'wp2static_addon_cloudflare_admin_scripts',
+            plugins_url( '../js/admin/batch-size-controller.js', __FILE__ ),
+            [],
+            Config::get('version'),
+            false
+        );
+        wp_enqueue_script( 'wp2static_addon_cloudflare_admin_scripts' );
     }
 }

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -23,7 +23,7 @@ use WP2Static\CoreOptions;
  */
 class Deployer
 {
-
+    public const BATCH_SIZE_DEFAULT = 10000;
     public function uploadFiles( string $processedSitePath ): void
     {
         if (Controller::getValue('useBulkUpload') === '1') {
@@ -211,9 +211,10 @@ class Deployer
         $batches = [];
 
         $filesInBatch = 0;
-        // TODO: add select menu for user-overriding batch size or be clever and auto-retry
-        // with smaller batch sizes on errors
-        $fileLimit = 10000;
+        $fileLimit = Controller::getValue("batchSize");
+        if( !$fileLimit || empty($fileLimit) ) {
+            $fileLimit = self::BATCH_SIZE_DEFAULT;
+        }
         $pathsInBatch = [];
 
         // TODO: Q: will iterator_to_array() allow rm'ing unused var?

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -211,8 +211,8 @@ class Deployer
         $batches = [];
 
         $filesInBatch = 0;
-        $fileLimit = Controller::getValue("batchSize");
-        if( !$fileLimit || empty($fileLimit) ) {
+        $fileLimit = Controller::getValue('batchSize');
+        if (!$fileLimit) {
             $fileLimit = self::BATCH_SIZE_DEFAULT;
         }
         $pathsInBatch = [];

--- a/tools/build_release.sh
+++ b/tools/build_release.sh
@@ -30,6 +30,7 @@ cp -r $EXEC_DIR/wp2static-addon-cloudflare-workers.php $TMP_DIR/wp2static-addon-
 cp -r $EXEC_DIR/src $TMP_DIR/wp2static-addon-cloudflare-workers/
 cp -r $EXEC_DIR/vendor $TMP_DIR/wp2static-addon-cloudflare-workers/
 cp -r $EXEC_DIR/views $TMP_DIR/wp2static-addon-cloudflare-workers/
+cp -r $EXEC_DIR/js $TMP_DIR/wp2static-addon-cloudflare-workers/
 
 cd $TMP_DIR
 

--- a/views/admin-page.latte
+++ b/views/admin-page.latte
@@ -89,6 +89,24 @@
             </td>
         </tr>
 
+        <tr id="batchSize__wrapper" class="{=(int) $options[useBulkUpload]->value === 0 ? hidden : ''}">
+            <td style="width:50%;">
+                <label for="{$options[batchSize]->name}">
+                  {$options[batchSize]->label}
+                </label>
+            </td>
+            <td>
+                <input
+                    id="{$options[batchSize]->name}"
+                    name="{$options[batchSize]->name}"
+                    type="number"
+                    min="1"
+                    max="10000"
+                    value="{$options[batchSize]->value}"
+                />
+            </td>
+        </tr>
+
     </tbody>
 </table>
 


### PR DESCRIPTION
Added an option to customise the batch size if using bulk uploads. I recall seeing this as a request on the support/WP forum and I thought there was an open issue too, but I can't find it.

I'm unsure if the Cloudflare addon is still actively maintained, however being an active user (and advocate) of WP2Static and this addon at work we would like to contribute any QoL changes and bug fixes where possible.